### PR TITLE
Fix to creating params and autoconverting to multiple arrays. Error: …

### DIFF
--- a/src/Db/Core.php
+++ b/src/Db/Core.php
@@ -274,7 +274,7 @@ class Core
      *
      * @param array|string $data The data to bind to string
      */
-    public function bind(...$bindings): self
+    public function bind($bindings): self
     {
         $this->bindings = $bindings;
         return $this;


### PR DESCRIPTION
…Array to string conversion.

When using in PHP 8.1.6, this error is happing:

**Array to string conversion.**

## Description

The problem that when executing with PHP 8.1.6, on passing bindings parameters using array, this is changing to multiple array and not a simple array.

Sendend: ->bind([':email' => 'test@email.com'])
At binding: [
  0 => [
    ':email' => 'test@email.com'
  ]
]
Expected: [
    ':email' => 'test@email.com'
  ]
