### PR TITLE
add support for client_encoding option with pgsql (fix #16)

### DIFF
--- a/src/Db/Core.php
+++ b/src/Db/Core.php
@@ -204,7 +204,11 @@ class Core
                 $dsn .= ';port=' . $this->config('port');
             }
             if ($this->config('charset')) {
-                $dsn .= ';charset=' . $this->config('charset');
+                if($dbtype === 'pgsql') {
+                    $dsn .= ';options=\'--client_encoding='.$this->config('charset').'\'';
+                } else {
+                    $dsn .= ';charset=' . $this->config('charset');
+                }
             }
             if ($this->config('unixSocket')) {
                 $dsn .= ';unix_socket=' . $this->config('unixSocket');


### PR DESCRIPTION
## What kind of change does this PR introduce? (pls check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe below

## Description

When connecting to a pgsql instance, option `charset` is not supported. The correct option to be set in the dsn should be `client_encoding`, see [docs](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-CLIENT-ENCODING).

## Does this PR introduce a breaking change? (check one)

- [ ] Yes
- [x] No

## Related Issue

See issue #16 .
