### PR TITLE
Sqlsrv connection string missing port and dbname

### DIFF
--- a/src/Db/Core.php
+++ b/src/Db/Core.php
@@ -193,6 +193,9 @@ class Core
             $dsn = "sqlite:$dbname";
         } elseif ($dbtype === 'sqlsrv') {
             $dsn = $dbtype . ":Server=" . $this->config('host');
+            if ($this->config('port')) {
+                $dsn .= "," . $this->config('port');
+            }
             $dsn .= ";Database=" . $this->config('database');
         } else {
             $dsn = "$dbtype:host=$host";

--- a/src/Db/Core.php
+++ b/src/Db/Core.php
@@ -196,7 +196,7 @@ class Core
             if ($this->config('port')) {
                 $dsn .= "," . $this->config('port');
             }
-            $dsn .= ";Database=" . $this->config('database');
+            $dsn .= ";Database=" . $this->config('dbname');
         } else {
             $dsn = "$dbtype:host=$host";
 


### PR DESCRIPTION
<!--
	Please only send a pull request to branches which are currently supported: https://leafphp.dev/community/contributing.html#pull-request-guidelines

	Pull requests without a descriptive title, thorough description, or tests will be closed.
-->

## What kind of change does this PR introduce? (pls check at least one)

<!-- (Update "[ ]" to "[x]" to check a box) -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe below

## Description

fix: sqlsrv no port from `.ENV` in connection string
fix: sqlsrv wrong name of variable with db name

## Does this PR introduce a breaking change? (check one)

<!-- We prefer to avoid breaking changes. We will only accept PRs with breaking changes if they have been discussed in an issue first -->

- [ ] Yes
- [X] No

## Related Issue

<!-- If suggesting a new feature or change, please discuss it in an issue first -->

<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
