### PR TITLE
feat: added transactions support

### DIFF
--- a/src/Db.php
+++ b/src/Db.php
@@ -356,4 +356,63 @@ class Db extends Db\Core
     {
         return $this->select($this->table)->where($row, 'LIKE', Utils::includes($value))->hidden($hidden)->all();
     }
+
+    /**
+     * Begin a database transaction
+     * 
+     * @return self
+     */
+    public function beginTransaction(): self
+    {
+        $this->query("START TRANSACTION");
+        $this->execute();
+
+        return $this;
+    }
+
+    /**
+     * Commit the current transaction
+     * 
+     * @return self
+     */
+    public function commit(): self
+    {
+        $this->query("COMMIT");
+        $this->execute();
+
+        return $this;
+    }
+
+    /**
+     * Rollback the current transaction
+     * 
+     * @return self
+     */
+    public function rollback(): self
+    {
+        $this->query("ROLLBACK");
+        $this->execute();
+
+        return $this;
+    }
+
+    /**
+     * Transaction shorthand
+     * 
+     * @param callable $callback The callback to run
+     * @return self
+     */
+    public function transaction($callback): self
+    {
+        try {
+            $this->beginTransaction();
+            $callback($this);
+            $this->commit();
+        } catch (\Exception $e) {
+            $this->rollback();
+            throw $e;
+        }
+
+        return $this;
+    }
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

<!-- (Update "[ ]" to "[x]" to check a box) -->

- [x] Feature
- [ ] Bugfix
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe below

## Description

This PR introduces support for database transactions in the `Leaf\Db` class. The following methods have been added to handle transactions:

- `beginTransaction`: Starts a database transaction.
- `commit`: Commits the current transaction.
- `rollback`: Rolls back the current transaction in case of an error.
- `transaction`: A shorthand method that accepts a callback, wrapping it in a transaction. If the callback throws an exception, the transaction is rolled back; otherwise, it is committed.

These additions make database interaction safer by ensuring that a series of operations can be treated as a single unit, either all succeeding or all failing, improving consistency and error handling.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Related Issue

No related issues were reported.