### PR TITLE
Remove `getenv` by using `_env` and `$_ENV` instead

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,5 +42,8 @@
     "allow-plugins": {
       "pestphp/pest-plugin": true
     }
+  },
+  "require": {
+    "ext-pdo": "*"
   }
 }

--- a/src/Db/Core.php
+++ b/src/Db/Core.php
@@ -192,7 +192,7 @@ class Core
     {
         // If `_env` function of Leaf is defined, use it.
         if (function_exists('_env')) {
-            return _env($name);
+            return _env($name, false);
         }
 
         // Return the value if found, otherwise false like getenv().

--- a/src/Db/Core.php
+++ b/src/Db/Core.php
@@ -167,13 +167,13 @@ class Core
     {
         return $this->connect(
             [
-                'dbtype' => getenv('DB_CONNECTION') ? getenv('DB_CONNECTION') : 'mysql',
-                'charset' => getenv('DB_CHARSET'),
-                'port' => getenv('DB_PORT') ? getenv('DB_PORT') : '3306',
-                'host' => getenv('DB_HOST') ? getenv('DB_HOST') : '127.0.0.1',
-                'username' => getenv('DB_USERNAME') ? getenv('DB_USERNAME') : 'root',
-                'password' => getenv('DB_PASSWORD') ? getenv('DB_PASSWORD') : '',
-                'dbname' => getenv('DB_DATABASE'),
+                'dbtype' => $this->env('DB_CONNECTION') ? $this->env('DB_CONNECTION') : 'mysql',
+                'charset' => $this->env('DB_CHARSET'),
+                'port' => $this->env('DB_PORT') ? $this->env('DB_PORT') : '3306',
+                'host' => $this->env('DB_HOST') ? $this->env('DB_HOST') : '127.0.0.1',
+                'username' => $this->env('DB_USERNAME') ? $this->env('DB_USERNAME') : 'root',
+                'password' => $this->env('DB_PASSWORD') ? $this->env('DB_PASSWORD') : '',
+                'dbname' => $this->env('DB_DATABASE'),
             ],
             '',
             '',
@@ -181,6 +181,21 @@ class Core
             '',
             $pdoOptions
         );
+    }
+
+    /**
+     * Returns the value of the environment variable by using Leaf's `_env` primarily.
+     * @param string $name
+     * @return string|bool
+     */
+    private function env(string $name): string|bool{
+        // If `_env` function of Leaf is defined, use it.
+        if(function_exists('_env')){
+            return _env($name);
+        }
+
+        // Return the value if found, otherwise false like getenv().
+        return $_ENV[$name] ?? false;
     }
 
     protected function dsn(): string

--- a/src/Db/Core.php
+++ b/src/Db/Core.php
@@ -188,9 +188,10 @@ class Core
      * @param string $name
      * @return string|bool
      */
-    private function env(string $name): string|bool{
+    private function env(string $name): string|bool
+    {
         // If `_env` function of Leaf is defined, use it.
-        if(function_exists('_env')){
+        if (function_exists('_env')) {
             return _env($name);
         }
 


### PR DESCRIPTION

## What kind of change does this PR introduce? (pls check at least one)


- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe below

## Description

The `getenv` function is not thread-safe. (See [vlucas/phpdotenv#putenv-and-getenv](https://github.com/vlucas/phpdotenv#putenv-and-getenv)) It breaks the core functionality of web sites.

In this pull request, I have removed `getenv` and made the module use Leaf's `_env` function instead to get environment variables. The change ensures that the functionality of this module does not break if you merge leafsphp/leaf#253 with the default branch of the main repo.

I could not run the tests. The credentials are not valid. 

I didn't check all Leaf modules for `getenv`, but all of its occurrences in modules should be replaced with `_env` and `$_ENV`.

## Does this PR introduce a breaking change? (check one)

- [ ] Yes
- [x] No

## Related Pull Request

leafsphp/leaf#253
