### PR TITLE
Reset errors in clear state

### DIFF
--- a/src/Db.php
+++ b/src/Db.php
@@ -48,29 +48,7 @@ class Db extends Db\Core
      */
     public function tableExists(string $table)
     {
-        $this->connection();
-
-        switch ($this->config['dbtype']) {
-            case 'sqlite':
-                $schema = $this->select('sqlite_master')->where(['type' => 'table', 'name' => $table])->all();
-                break;
-
-            case 'mysql':
-                $schema = $this->select('INFORMATION_SCHEMA.TABLES')->where(['TABLE_SCHEMA' => $this->config['dbname'], 'TABLE_NAME' => $table])->all();
-                break;
-
-            case 'pgsql':
-                $schema = $this->select('pg_catalog.pg_tables')->where(['schemaname' => 'public', 'tablename' => $table])->all();
-                break;
-
-            case 'sqlsrv':
-                $schema = $this->select('information_schema.tables')->where(['table_schema' => 'dbo', 'table_name' => $table])->all();
-                break;
-
-            default:
-                $schema = $this->select('INFORMATION_SCHEMA.SCHEMATA')->where('SCHEMA_NAME', $table)->all();
-                break;
-        }
+        $schema = $this->select('INFORMATION_SCHEMA.SCHEMATA')->where('SCHEMA_NAME', $table)->all();
 
         return count($schema) > 0;
     }
@@ -328,11 +306,97 @@ class Db extends Db\Core
     }
 
     /**
-     * Fetch current query with all related data
+     * Add a JSON where clause to the query
      *
+     * @param string $column The JSON column
+     * @param string $jsonKey The key within the JSON structure
+     * @param mixed $value The value to compare against
+     * @param string $comparator The comparison operator (default '=')
+     */
+    public function whereJson(string $column, string $jsonKey, $value, string $comparator = '='): self
+    {
+        // Check if the value is an integer, and cast the JSON value to an integer
+        $jsonExpression = is_int($value)
+            ? "JSON_EXTRACT($column, '$.$jsonKey') + 0" # just incase: ? "CAST(JSON_EXTRACT($column, '$.$jsonKey') AS UNSIGNED)";
+            : "JSON_EXTRACT($column, '$.$jsonKey')";
+
+        $this->query = Builder::where($this->query, $jsonExpression, $value, $comparator);
+        $this->bind(...(Builder::$bindings));
+
+        return $this;
+    }
+
+    /**
+     * Add a JSON where clause with OR comparator to the query
+     *
+     * @param string $column The JSON column
+     * @param string $jsonKey The key within the JSON structure
+     * @param mixed $value The value to compare against
+     * @param string $comparator The comparison operator (default '=')
+     */
+    public function orWhereJson(string $column, string $jsonKey, $value, string $comparator = '='): self
+    {
+        $jsonExpression = is_int($value)
+            ? "JSON_EXTRACT($column, '$.$jsonKey') + 0"
+            : "JSON_EXTRACT($column, '$.$jsonKey')";
+
+        $this->query = Builder::where($this->query, $jsonExpression, $value, $comparator, 'OR');
+        $this->bind(...(Builder::$bindings));
+
+        return $this;
+    }
+
+    /**
+     * Add a JSON contains clause to the query
+     *
+     * @param string $column The JSON column
+     * @param mixed $value The value to check for
+     * @param string|null $jsonKey The key within the JSON structure (optional)
+     */
+    public function whereJsonContains(string $column, $value, ?string $jsonKey = null): self
+    {
+        $jsonValue = json_encode($value, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+
+        $jsonExpression = $jsonKey
+            ? "JSON_CONTAINS($column, ?, '$.$jsonKey')"
+            : "JSON_CONTAINS($column, ?)";
+
+        
+        Builder::$bindings[] = $jsonValue;
+        $this->query = Builder::where($this->query, $jsonExpression, 1, '=');
+        $this->bind(...(Builder::$bindings));
+
+        return $this;
+    }
+    
+    /**
+     * Add a JSON contains clause with OR comparator to the query
+     *
+     * @param string $column The JSON column
+     * @param mixed $value The value to check for
+     * @param string|null $jsonKey The key within the JSON structure (optional)
+     */
+    public function orWhereJsonContains(string $column, $value, ?string $jsonKey = null): self
+    {
+        $jsonValue = json_encode($value, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+
+        $jsonExpression = $jsonKey
+            ? "JSON_CONTAINS($column, ?, '$.$jsonKey')"
+            : "JSON_CONTAINS($column, ?)";
+
+        Builder::$bindings[] = $jsonValue;
+        $this->query = Builder::where($this->query, $jsonExpression, 1, '=', 'OR');
+        $this->bind(...(Builder::$bindings));
+
+        return $this;
+    }
+
+    /**
+     * Fetch current query with all related data
+     * 
      * @param string $table The table to join
      * @param string $foreignKey The foreign key to use
-     *
+     * 
      * @return self
      */
     public function with(string $table, string $foreignKey = null)
@@ -440,7 +504,7 @@ class Db extends Db\Core
     }
 
     /**
-     * Run a database transaction
+     * Short Hand database transaction
      *
      * @param callable $callback The callback to run
      *

--- a/src/Db/Core.php
+++ b/src/Db/Core.php
@@ -735,6 +735,7 @@ class Core
         $this->hidden = [];
         $this->added = [];
         $this->params = [];
+        $this->errors = [];
     }
 
     /**


### PR DESCRIPTION
<!--
	Please only send a pull request to branches which are currently supported: https://leafphp.dev/community/contributing.html#pull-request-guidelines

	Pull requests without a descriptive title, thorough description, or tests will be closed.
-->

## What kind of change does this PR introduce? (pls check at least one)

<!-- (Update "[ ]" to "[x]" to check a box) -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe below

## Description
This PR updates the clearState() method to also reset the $errors array. Previously, the method cleared several internal state properties but did not include $errors, which could lead to stale error messages persisting between queries.
<!--
	Describe your changes in detail. In addition, please describe the benefit to end users; how it makes building easier, etc.
	You can link to issues here.
-->

## Does this PR introduce a breaking change? (check one)

<!-- We prefer to avoid breaking changes. We will only accept PRs with breaking changes if they have been discussed in an issue first -->

- [ ] Yes
- [x] No

## Related Issue
Fixes #31 
<!-- If suggesting a new feature or change, please discuss it in an issue first -->

<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
